### PR TITLE
Fix KeyError on first run with no existing trades.csv

### DIFF
--- a/update_utils/process_live.py
+++ b/update_utils/process_live.py
@@ -142,13 +142,16 @@ def process_live():
 
     df = df.with_row_index()
 
-    same_timestamp = df.filter(pl.col('timestamp') == last_processed['timestamp'])
-    same_timestamp = same_timestamp.filter(
-        (pl.col("transactionHash") == last_processed['transactionHash']) & (pl.col("maker") == last_processed['maker']) & (pl.col("taker") == last_processed['taker'])
-    )
+    if last_processed:
+        same_timestamp = df.filter(pl.col('timestamp') == last_processed['timestamp'])
+        same_timestamp = same_timestamp.filter(
+            (pl.col("transactionHash") == last_processed['transactionHash']) & (pl.col("maker") == last_processed['maker']) & (pl.col("taker") == last_processed['taker'])
+        )
 
-    df_process = df.filter(pl.col('index') > same_timestamp.row(0)[0])
-    df_process = df_process.drop('index')
+        df_process = df.filter(pl.col('index') > same_timestamp.row(0)[0])
+        df_process = df_process.drop('index')
+    else:
+        df_process = df.drop('index')
 
     print(f"⚙️  Processing {len(df_process):,} new rows...")
 


### PR DESCRIPTION
## Summary
- `process_live()` crashes with `KeyError: 'timestamp'` on first run when `processed/trades.csv` doesn't exist yet
- `last_processed` stays as an empty dict `{}`, then line 145 accesses `last_processed['timestamp']`
- Fix: guard the resume-filtering behind `if last_processed:` so the first run processes all rows

## Repro
```bash
# fresh clone, no processed/ directory
python update_all.py
# KeyError: 'timestamp' at process_live.py:145
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)